### PR TITLE
feat: Created Access Points for Dev Console to read write cube data

### DIFF
--- a/bloomstack_core/bloomstack_core/doctype/admin_insights/admin_insights.js
+++ b/bloomstack_core/bloomstack_core/doctype/admin_insights/admin_insights.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2021, Bloom Stack, Inc and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('Admin Insights', {
+	// refresh: function(frm) {
+
+	// }
+});

--- a/bloomstack_core/bloomstack_core/doctype/admin_insights/admin_insights.json
+++ b/bloomstack_core/bloomstack_core/doctype/admin_insights/admin_insights.json
@@ -1,0 +1,78 @@
+{
+ "autoname": "ADI-.YYYY.-.#####",
+ "creation": "2021-01-03 20:32:37.061782",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "type",
+  "data_object",
+  "amended_from"
+ ],
+ "fields": [
+  {
+   "fieldname": "type",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Type",
+   "options": "\nCards\nGraphs",
+   "reqd": 1
+  },
+  {
+   "fieldname": "data_object",
+   "fieldtype": "Long Text",
+   "label": "Data Object",
+   "reqd": 1
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "Admin Insights",
+   "print_hide": 1,
+   "read_only": 1
+  }
+ ],
+ "is_submittable": 1,
+ "modified": "2021-01-05 22:11:27.309095",
+ "modified_by": "Administrator",
+ "module": "Bloomstack Core",
+ "name": "Admin Insights",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "amend": 1,
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Administrator",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  }
+ ],
+ "quick_entry": 1,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "track_changes": 1
+}

--- a/bloomstack_core/bloomstack_core/doctype/admin_insights/admin_insights.py
+++ b/bloomstack_core/bloomstack_core/doctype/admin_insights/admin_insights.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021, Bloom Stack, Inc and contributors
+# For license information, please see license.txt
+
+from __future__ import unicode_literals
+# import frappe
+from frappe.model.document import Document
+
+class AdminInsights(Document):
+	pass

--- a/bloomstack_core/bloomstack_core/doctype/admin_insights/test_admin_insights.py
+++ b/bloomstack_core/bloomstack_core/doctype/admin_insights/test_admin_insights.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021, Bloom Stack, Inc and Contributors
+# See license.txt
+from __future__ import unicode_literals
+
+# import frappe
+import unittest
+
+class TestAdminInsights(unittest.TestCase):
+	pass

--- a/bloomstack_core/bloomstack_core/page/admin_insights/admin_insights.py
+++ b/bloomstack_core/bloomstack_core/page/admin_insights/admin_insights.py
@@ -1,7 +1,33 @@
 import frappe
-
+import json
 
 @frappe.whitelist(allow_guest=True)
 def get_cubejs_host(cube_js_name="cubejs"):
-    doc=frappe.get_doc("Cubejs",{"cube_js_name":cube_js_name})
-    return doc
+	doc=frappe.get_doc("Cubejs",{"cube_js_name":cube_js_name})
+	return doc
+
+@frappe.whitelist(allow_guest=True)
+def get_all_insights_data(types=None):
+	fetched_data = []
+	if not types:
+		fetched_data.append(frappe.db.get_list("Admin Insights", fields= ["data_object"]))
+		# print("-----------------------------", fetched_data)
+		return fetched_data
+	datas = frappe.get_all("Admin Insights", filters={'type': ['=', types]})
+	if not datas:
+		return "No Data Found For Type "+ types
+
+	for data in datas:
+		fetched_data.append(json.loads(frappe.get_value("Admin Insights", data.name , ["data_object"])))
+
+	print(fetched_data)
+	return fetched_data
+
+@frappe.whitelist()
+def create_admin_insights(types, data_object):
+	doc = frappe.new_doc("Admin Insights")
+	doc.type = types
+	doc.data_object = data_object
+	doc.insert()
+	doc.submit()
+	return "The Data Is Inserted"


### PR DESCRIPTION
In this PR we have 2 APIs created:

1. get_all_insights_data: to read all data related to the selected type
2.  create_admin_insights: to write new data to the system.
